### PR TITLE
156 cov

### DIFF
--- a/bacnet.html
+++ b/bacnet.html
@@ -515,3 +515,204 @@
         }
     });
 </script>
+
+
+<script type="text/x-red" data-template-name="bacnet-subscribe-property">
+    <div class="form-row">
+        <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+    <div class="form-row">
+        <label for="node-input-address"><i class="icon-bookmark"></i> Address</label>
+        <input type="text" id="node-input-address" placeholder="">
+    </div>
+    <div class="form-row">
+        <label for="node-input-objectType"><i class="icon-bookmark"></i> Object Type</label>
+        <input type="text" id="node-input-objectType" placeholder="">
+    </div>
+    <div class="form-row">
+        <label for="node-input-objectInstance"><i class="icon-bookmark"></i> Object Instance</label>
+        <input type="text" id="node-input-objectInstance" placeholder="">
+    </div>
+    <div class="form-row">
+        <label for="node-input-propertyId"><i class="icon-bookmark"></i> Property ID</label>
+        <input type="text" id="node-input-propertyId" placeholder="">
+    </div>
+    <div class="form-row">
+        <label for="node-input-arrayIndex"><i class="icon-bookmark"></i> Array Index</label>
+        <input type="text" id="node-input-arrayIndex" placeholder="">
+    </div>
+    <div class="form-row">
+        <label for="node-input-arrayIndex"><i class="icon-bookmark"></i> Subscribe ID</label>
+        <input type="text" id="node-input-subscribeId" placeholder="">
+    </div>
+    <div class="form-row">
+        <label for="node-input-arrayIndex"><i class="icon-bookmark"></i> Issue confirmed notifications</label>
+        <input type="checkbox" id="node-input-issueConfirmedNotifications" placeholder="">
+    </div>
+    <div class="form-row">
+        <label for="node-input-server"><i class="icon-globe"></i> Server</label>
+        <input type="text" id="node-input-server">
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="bacnet-subscribe-property">
+    <p>The <code>subscribeProperty</code> command subscribes to a specified objects single properties changes. It accepts an input whose device property will override the properties set here.</p>
+    <ul>
+        <li><code>address</code> <em>[string]</em> - IP address of the target device.</li>
+        <li><code>objectType</code> <em>[number]</em> - The BACNET object type to read.</li>
+        <li><code>objectInstance</code> <em>[number]</em> - The BACNET object instance to read.</li>
+        <li><code>propertyId</code> <em>[number]</em> - The BACNET property id in the specified object to read.</li>
+        <li><code>arrayIndex</code> <em>[number]</em> - The array index of the property to be read.</li>
+        <li><code>subscribeId</code> <em>[number]</em> - Subscription identifier.</li>
+        <li><code>issueConfirmedNotifications</code> <em>[boolean]</em> - Controls whether the the subscription uses confirmations.</li>
+    </ul>
+</script>
+
+<script type="text/javascript">
+    RED.nodes.registerType('bacnet-subscribe-property', {
+        category: 'bacnet',
+        color: '#E9967A',
+        defaults: {
+            address: {
+                value: '',
+                required: false
+            },
+            objectType: {
+                value: '',
+                required: false,
+                validate: RED.validators.number()
+            },
+            objectInstance: {
+                value: '',
+                required: false,
+                validate: RED.validators.number()
+            },
+            propertyId: {
+                value: '',
+                required: false,
+                validate: RED.validators.number()
+            },
+            arrayIndex: {
+                value: undefined
+            },
+            subscribeId: {
+                value: '',
+                required: false,
+                validate: RED.validators.number()
+            },
+            issueConfirmedNotifications: {
+                value: false,
+                required: false
+            },
+            server: {
+                value: '',
+                type: 'bacnet-server'
+            }
+        },
+        inputs: 1,
+        outputs: 1,
+        icon: 'automation.gif',
+        paletteLabel: 'BACnet subscribe property',
+        label: function() {
+            return (this.name || 'BACnet subscribe property');
+        }
+    });
+</script>
+
+
+<script type="text/x-red" data-template-name="bacnet-subscribe-cov">
+    <div class="form-row">
+        <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+    <div class="form-row">
+        <label for="node-input-address"><i class="icon-bookmark"></i> Address</label>
+        <input type="text" id="node-input-address" placeholder="">
+    </div>
+    <div class="form-row">
+        <label for="node-input-objectType"><i class="icon-bookmark"></i> Object Type</label>
+        <input type="text" id="node-input-objectType" placeholder="">
+    </div>
+    <div class="form-row">
+        <label for="node-input-objectInstance"><i class="icon-bookmark"></i> Object Instance</label>
+        <input type="text" id="node-input-objectInstance" placeholder="">
+    </div>
+    <div class="form-row">
+        <label for="node-input-arrayIndex"><i class="icon-bookmark"></i> Subscribe ID</label>
+        <input type="text" id="node-input-subscribeId" placeholder="">
+    </div>
+    <div class="form-row">
+        <label for="node-input-arrayIndex"><i class="icon-bookmark"></i> Issue confirmed notifications</label>
+        <input type="checkbox" id="node-input-issueConfirmedNotifications" placeholder="">
+    </div>
+    <div class="form-row">
+        <label for="node-input-arrayIndex"><i class="icon-bookmark"></i> Lifetime</label>
+        <input type="text" id="node-input-lifetime" placeholder="">
+    </div>
+    <div class="form-row">
+        <label for="node-input-server"><i class="icon-globe"></i> Server</label>
+        <input type="text" id="node-input-server">
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="bacnet-subscribe-cov">
+    <p>The <code>subscribeCOV</code> command subscribes to a specified objects changes. It accepts an input whose device property will override the properties set here.</p>
+    <ul>
+        <li><code>address</code> <em>[string]</em> - IP address of the target device.</li>
+        <li><code>objectType</code> <em>[number]</em> - The BACNET object type to read.</li>
+        <li><code>objectInstance</code> <em>[number]</em> - The BACNET object instance to read.</li>
+        <li><code>subscribeId</code> <em>[number]</em> - Subscription identifier.</li>
+        <li><code>issueConfirmedNotifications</code> <em>[boolean]</em> - Controls whether the the subscription uses confirmations.</li>
+        <li><code>lifetime</code> <em>[number]</em> - Subscription lifetime.</li>
+    </ul>
+</script>
+
+<script type="text/javascript">
+    RED.nodes.registerType('bacnet-subscribe-cov', {
+        category: 'bacnet',
+        color: '#E9967A',
+        defaults: {
+            address: {
+                value: '',
+                required: false
+            },
+            objectType: {
+                value: '',
+                required: false,
+                validate: RED.validators.number()
+            },
+            objectInstance: {
+                value: '',
+                required: false,
+                validate: RED.validators.number()
+            },
+            subscribeId: {
+                value: '',
+                required: false,
+                validate: RED.validators.number()
+            },
+            issueConfirmedNotifications: {
+                value: false,
+                required: false,
+            },
+            lifetime: {
+                value: 0,
+                required: false,
+                validate: RED.validators.number()
+            },
+            server: {
+                value: '',
+                type: 'bacnet-server'
+            }
+        },
+        inputs: 1,
+        outputs: 1,
+        icon: 'automation.gif',
+        paletteLabel: 'BACnet subscribe COV',
+        label: function() {
+            return (this.name || 'BACnet subscribe COV');
+        }
+    });
+</script>
+

--- a/lib/bacnet.js
+++ b/lib/bacnet.js
@@ -4,19 +4,35 @@ class Bacnet {
     constructor(options) {
         this.options = options;
         this.devices = new Map();
+        this.subscriptions = {};
         this.connect(this.options);
     }
 
     onDestroy() {
         if (this.client) {
             this.client.removeAllListeners('iAm');
+            this.client.removeAllListeners('covNotify');
+            this.client.removeAllListeners('covNotifyUnconfirmed');
             this.client.close();
+            this.client = null;
         }
     }
 
     connect(options) {
         this.client = new bacnet(options);
+
         this.client.on('iAm', (device) => this.onDeviceAdded(device));
+        this.client.on('covNotify', (data) => {
+            if (!this.hasSubscription(data.address, data.request.subscriberProcessIdentifier)) { return; }
+
+            this.client.simpleAckResponse(data.address, bacnet.enum.BacnetConfirmedServices.SERVICE_CONFIRMED_COV_NOTIFICATION, data.invokeId);
+            this.subscriptions[data.address][data.request.subscriberProcessIdentifier](data.request.values);
+        })
+        this.client.on('covNotifyUnconfirmed', (data) => {
+            if (!this.hasSubscription(data.address, data.request.subscriberProcessIdentifier)) { return; }
+            
+            this.subscriptions[data.address][data.request.subscriberProcessIdentifier](data.request.values);
+        })
     }
 
     onDeviceAdded(device) {
@@ -34,10 +50,7 @@ class Bacnet {
         return new Promise((resolve, reject) => {
             if (!this.client) { return reject('Not connected'); }
 
-            this.client.readProperty(address, objectType, objectInstance, propertyId, arrayIndex, (err, value) => {
-                if (err) { return reject(err); }
-                return resolve(value);
-            });
+            this.client.readProperty(address, objectType, objectInstance, propertyId, arrayIndex, (err, value) => err ? reject(err) : resolve(value));
         });
     }
 
@@ -46,10 +59,8 @@ class Bacnet {
         
         return new Promise((resolve, reject) => {
             if (!this.client) { return reject('Not connected'); }
-            this.client.writeProperty(address, objectType, objectInstance, propertyId, priority, valueList, (err, value) => {
-                if (err) { return reject(err); }
-                return resolve(value);
-            })
+
+            this.client.writeProperty(address, objectType, objectInstance, propertyId, priority, valueList, (err, value) => err ? reject(err) : resolve(value));
         });
     }
 
@@ -57,10 +68,7 @@ class Bacnet {
         return new Promise((resolve, reject) => {
             if (!this.client) { return reject('Not connected'); }
 
-            this.client.readPropertyMultiple(address, requestArray, (err, value) => {
-                if (err) { return reject(err); }
-                return resolve(value);
-            });
+            this.client.readPropertyMultiple(address, requestArray, (err, value) => err ? reject(err) : resolve(value));
         });
     }
     
@@ -68,11 +76,66 @@ class Bacnet {
         return new Promise((resolve, reject) => {
             if (!this.client) { return reject('Not connected'); }
 
-            this.client.writePropertyMultiple(address, valueList, (err, value) => {
+            this.client.writePropertyMultiple(address, valueList, (err, value) => err ? reject(err) : resolve(value));
+        });
+    }
+
+    subscribeProperty(address, objectId, propertyId, subscribeId, issueConfirmedNotifications, listener) {
+        return new Promise((resolve, reject) => {
+            if (!this.client) { return reject('Not connected'); }
+
+            this.client.subscribeProperty(address, objectId, propertyId, subscribeId, false, issueConfirmedNotifications, (err, value) => {
                 if (err) { return reject(err); }
+
+                this.subscriptions[address] = Object.assign({}, this.subscriptions[address], { [subscribeId]: listener });
                 return resolve(value);
             });
         });
+    }
+    
+    subscribeCOV(address, objectId, subscribeId, issueConfirmedNotifications, lifetime, listener) {
+        return new Promise((resolve, reject) => {
+            if (!this.client) { return reject('Not connected'); }
+            
+            this.client.subscribeCOV(address, objectId, subscribeId, false, issueConfirmedNotifications, lifetime, (err, value) => {
+                if (err) { return reject(err); }
+                
+                this.subscriptions[address] = Object.assign({}, this.subscriptions[address], { [subscribeId]: listener });
+                return resolve(value);
+            });
+        })
+    }
+
+    unsubscribeProperty(address, subscribeId, objectId, propertyId) {
+        return new Promise((resolve, reject) => {
+            if (!this.client) { return reject('Not connected'); }
+            if (!this.hasSubscription(address, subscribeId)) { return reject('Not subscribed'); }
+
+            this.client.subscribeProperty(address, objectId, propertyId, subscribeId, true, null, (err, value) => {
+                if (err) { return reject(err); }
+
+                delete this.subscriptions[address][subscribeId];
+                return resolve(value);
+            });
+        })
+    }
+    
+    unsubscribeCOV(address, subscribeId, objectId) {
+        return new Promise((resolve, reject) => {
+            if (!this.client) { return reject('Not connected'); }
+            if (!this.hasSubscription(address, subscribeId)) { return reject('Not subscribed'); }
+
+            this.client.subscribeCOV(address, objectId, subscribeId, true, null, null, (err, value) => {
+                if (err) { return reject(err); }
+
+                delete this.subscriptions[address][subscribeId];
+                return resolve(value);
+            });
+        })
+    }
+
+    hasSubscription(address, subscriptionId) {
+        return this.subscriptions[address] && this.subscriptions[address][subscriptionId];
     }
 
     toNumber(value) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/goliatone/node-red-contrib-bacnet#readme",
   "dependencies": {
-    "bacstack": "0.0.1-beta.11"
+    "bacstack": "github:klemensas/node-bacstack#COV_changes"
   },
   "node-red": {
     "nodes": {


### PR DESCRIPTION
Closes https://github.com/spry-group/automata-conductor/issues/156

This PR adds  COV and property subscriptions.
Supports both confirmed and unconfirmed notifications.
I was only able to test property subscription.

I've updated https://github.com/klemensas/automata-conductor/tree/56_bacnet example to include property subscription.


Some implementation notes:
- Didn't add additional read on subscription as it seems already to receive the current state on subscribing. Not sure if this is device specific.
- Went with manually managed subscription ids.
- Assumed that a node should only have one active subscription and added an unsubscribe on new input.
- Didn't add any lifetime handling.